### PR TITLE
Support coloring of messages

### DIFF
--- a/CUDLR/Scripts/Console.cs
+++ b/CUDLR/Scripts/Console.cs
@@ -146,30 +146,46 @@ namespace CUDLR {
     /* Returns the output */
     public static string Output()
     {
-        return Output(false);
-    }
-
-    /* Returns the output, if useHtml is true will use divs instead of \n for logging */
-    public static string Output(bool useHtml) {
         StringBuilder s = new StringBuilder();
         foreach (ConsoleMessage m in Instance.m_output)
         {
-            if (useHtml)
-            {
-                //Use regex to remove most valid HTML... FIX - won't catch all cases unfortunately but could be improved later
-                string htmlString = Regex.Replace(m.message, @"<[^>]*>", String.Empty);
-                s.Append("<div style='color:#" + m.color.r.ToString("X2") + m.color.g.ToString("X2") + m.color.b.ToString("X2") + ";'>");
-                s.Append(htmlString);
-                s.Append("</div>");
-            }
-            else
-            {
-                s.Append(m.message);
-                s.Append("\n");
-            }
+            //HTML Encode the string message to prevent the div's innerText from being parsed as HTML
+            string htmlString = HtmlEncode(m.message);
+            s.Append("<div style='color:#" + m.color.r.ToString("X2") + m.color.g.ToString("X2") + m.color.b.ToString("X2") + ";'>");
+            s.Append(htmlString);
+            s.Append("</div>");
         }
         return s.ToString(); ;
+    }
 
+    private static string HtmlEncode(string text)
+    {
+        if (text == null) return null;
+
+        StringBuilder s = new StringBuilder(text.Length);
+        for (int i = 0; i < text.Length; i++)
+        {
+            switch (text[i])
+            {
+
+                case '<':
+                    s.Append("&lt;");
+                    break;
+                case '>':
+                    s.Append("&gt;");
+                    break;
+                case '"':
+                    s.Append("&quot;");
+                    break;
+                case '&':
+                    s.Append("&amp;");
+                    break;
+                default:
+                    s.Append(text[i]);
+                    break;
+            }
+        }
+        return s.ToString();
     }
 
     /* Register a new console command */
@@ -249,7 +265,7 @@ namespace CUDLR {
     // Our routes
     [Route("^/console/out$")]
     public static void Output(RequestContext context) {
-      context.Response.WriteString(Console.Output(true));
+      context.Response.WriteString(Console.Output());
     }
 
     [Route("^/console/run$")]

--- a/CUDLR/Scripts/Console.cs
+++ b/CUDLR/Scripts/Console.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;   
 using System.Linq;
 using System.Reflection;
 using System.Net;
@@ -49,14 +49,12 @@ namespace CUDLR {
     private List<string> m_history;
     private string m_help;
     private Queue<QueuedCommand> m_commandQueue;
-    private Dictionary<string, Color32> m_messageColors;
 
     private Console() {
       m_commands = new CommandTree();
       m_output = new List<ConsoleMessage>();
       m_history = new List<string>();
       m_commandQueue = new Queue<QueuedCommand>();
-      m_messageColors = new Dictionary<string, Color32>();
 
       RegisterAttributes();
     }
@@ -116,21 +114,14 @@ namespace CUDLR {
 
     /* Logs string to output */
     public static void Log(string str) {
-        Log(str, "");
+        Log(str, new Color32(240, 240, 240, 255)); //Default message color if not specified);
     }
 
-    /* Logs string to output with specified color corresponding to the message color name */
-    public static void Log(string str, string colorName)
+    /* Logs string to output using the specified color */
+    public static void Log(string str, Color32 color)
     {
-        if((str != "") && (Instance.m_messageColors.ContainsKey(colorName)))
-        {
-            Instance.m_output.Add(new ConsoleMessage(str, Instance.m_messageColors[colorName]));
-        }
-        else
-        {
-            Instance.m_output.Add(new ConsoleMessage(str));
-        }
-
+        Instance.m_output.Add(new ConsoleMessage(str, color));
+        
         if (Instance.m_output.Count > MAX_LINES)
             Instance.m_output.RemoveAt(0);
     }
@@ -201,14 +192,6 @@ namespace CUDLR {
       Instance.m_help += string.Format("\n{0} : {1}", command, desc);
     }
 
-    /* Register user defined message colors */
-    public static void RegisterMessageColors(MessageColors[] messageColors)
-    {
-        foreach (MessageColors mc in messageColors)
-        {
-            Instance.m_messageColors.Add(mc.name, mc.color);
-        }
-    }
     private void RegisterAttributes() {
       foreach(Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()) {
         foreach(Type type in assembly.GetTypes()) {

--- a/CUDLR/Scripts/Server.cs
+++ b/CUDLR/Scripts/Server.cs
@@ -35,20 +35,11 @@ namespace CUDLR {
     }
   }
 
-  //Struct to contain message name and colors
-  [Serializable]
-  public struct MessageColors
-  {
-      public string name;
-      public Color32 color;
-  }
-
   public class Server : MonoBehaviour {
 
     [SerializeField]
     public int Port = 55055;
 
-    public MessageColors[] messageColors;
     private static Thread mainThread;
     private static string fileRoot;
     private static HttpListener listener = new HttpListener();
@@ -76,7 +67,6 @@ namespace CUDLR {
 
       RegisterRoutes();
       RegisterFileHandlers();
-      Console.RegisterMessageColors(messageColors);  //Ensure the console instance also is aware of the user specified colors
 
       // Start server
       Debug.Log("Starting CUDLR Server on port : " + Port);

--- a/CUDLR/Scripts/Server.cs
+++ b/CUDLR/Scripts/Server.cs
@@ -40,7 +40,7 @@ namespace CUDLR {
   public struct MessageColors
   {
       public string name;
-      public Color color;
+      public Color32 color;
   }
 
   public class Server : MonoBehaviour {

--- a/CUDLR/Scripts/Server.cs
+++ b/CUDLR/Scripts/Server.cs
@@ -35,6 +35,7 @@ namespace CUDLR {
     }
   }
 
+
   public class Server : MonoBehaviour {
 
     [SerializeField]

--- a/CUDLR/Scripts/Server.cs
+++ b/CUDLR/Scripts/Server.cs
@@ -35,12 +35,20 @@ namespace CUDLR {
     }
   }
 
+  //Struct to contain message name and colors
+  [Serializable]
+  public struct MessageColors
+  {
+      public string name;
+      public Color color;
+  }
 
   public class Server : MonoBehaviour {
 
     [SerializeField]
     public int Port = 55055;
 
+    public MessageColors[] messageColors;
     private static Thread mainThread;
     private static string fileRoot;
     private static HttpListener listener = new HttpListener();
@@ -68,6 +76,7 @@ namespace CUDLR {
 
       RegisterRoutes();
       RegisterFileHandlers();
+      Console.RegisterMessageColors(messageColors);  //Ensure the console instance also is aware of the user specified colors
 
       // Start server
       Debug.Log("Starting CUDLR Server on port : " + Port);

--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ We wrote CUDLR to use in [Proletariat's](http://www.proletariat.com) upcoming ga
 * Command history
 * Standard text-entry shortcuts (ctrl-a, ctrl-e, etc)
 * Uses standard HTML/CSS for layout
+* Supports displaying of context specific colored messages
  
 How do I use CUDLR?
 ----
 * Download the unitypackage from github or the [Unity Asset Store](https://www.assetstore.unity3d.com/#/content/12294) and import it in to your project.
 * Create an empty GameObject in the scene and add the CUDLR->Server component.
+* To use message coloring, on the empty GameObject containing the Server script, update the "Message Colors" array to 
+  define the colors used by your game's logging. Both Name and Color for each element should be defined, and Name
+  should be unique for each color.
 * Set the port on the component (default value is 55055).
 * Add the CUDLR.Command attribute to your code.
 * Run the game and connect to http://localhost:55055 with your browser.
@@ -54,6 +58,11 @@ Delegate functions can output data to the console by calling the CUDLR Console L
 CUDLR.Console.Log( <Log String> );
 ```
 
+To use message coloring defined on the GameObject containing the Server script, use the alternate CUDLR Console Log function, specifying the color Name (as specified on the Server GameObject) as the second parameter:
+
+```
+CUDLR.Console.Log( <Log String> , <color name as defined on the Server GameObject> );
+```
 Adding Additional Routes
 ----
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,12 @@ We wrote CUDLR to use in [Proletariat's](http://www.proletariat.com) upcoming ga
 * Command history
 * Standard text-entry shortcuts (ctrl-a, ctrl-e, etc)
 * Uses standard HTML/CSS for layout
-* Supports displaying of context specific colored messages
+* Supports displaying of colored log messages
  
 How do I use CUDLR?
 ----
 * Download the unitypackage from github or the [Unity Asset Store](https://www.assetstore.unity3d.com/#/content/12294) and import it in to your project.
 * Create an empty GameObject in the scene and add the CUDLR->Server component.
-* To use message coloring, on the empty GameObject containing the Server script, update the "Message Colors" array to 
-  define the colors used by your game's logging. Both Name and Color for each element should be defined, and Name
-  should be unique for each color.
 * Set the port on the component (default value is 55055).
 * Add the CUDLR.Command attribute to your code.
 * Run the game and connect to http://localhost:55055 with your browser.
@@ -58,10 +55,10 @@ Delegate functions can output data to the console by calling the CUDLR Console L
 CUDLR.Console.Log( <Log String> );
 ```
 
-To use message coloring defined on the GameObject containing the Server script, use the alternate CUDLR Console Log function, specifying the color Name (as specified on the Server GameObject) as the second parameter:
+To use message coloring defined on the GameObject containing the Server script, use the alternate CUDLR Console Log function, specifying the color to use:
 
 ```
-CUDLR.Console.Log( <Log String> , <color name as defined on the Server GameObject> );
+CUDLR.Console.Log( <Log String> , <Color32 Color> );
 ```
 Adding Additional Routes
 ----

--- a/StreamingAssets/CUDLR/console.css
+++ b/StreamingAssets/CUDLR/console.css
@@ -1,4 +1,5 @@
 textarea {resize:none;}
+div {resize:none;}
 
 body.console {
   background-color:black;
@@ -8,9 +9,24 @@ textarea.console {
   background-color:#383838;
   color:#F0F0F0;
   font-size:14px;
-  font-family:;"Courier New", Courier, monospace;
+  font-family:"Courier New", Courier, monospace;
 
 }
+
+div.console {
+    -moz-appearance: textfield-multiline;
+    -webkit-appearance: textarea;
+    border: 1px solid gray;
+    overflow: auto;
+    padding: 2px;
+    width:100%;
+    background-color:#383838;
+    color:#F0F0F0;
+    font-size:14px;
+    font-family:"Courier New", Courier, monospace;
+    white-space: pre;
+}
+
 #output {
   height:500px;
 }

--- a/StreamingAssets/CUDLR/index.html
+++ b/StreamingAssets/CUDLR/index.html
@@ -32,7 +32,7 @@
           // Check if we are scrolled to the bottom to force scrolling on update
           var output = $('#output');
           shouldScroll = (output[0].scrollHeight - output.scrollTop()) == output.innerHeight();
-          output.val(String(data));
+          output.html(String(data));
           if (callback) callback();
           if (shouldScroll) scrollBottom();
         });
@@ -80,7 +80,7 @@
   </head>
 
   <body class="console">
-    <textarea id="output" class="console" readOnly></textarea>
+    <div id="output" class="console"></div>
     <textarea id="input" class="console" autofocus rows="1"></textarea>
 
     <script>


### PR DESCRIPTION
Hello,
I saw an issue request for supporting colored log messages and thought this sounded like a fun small project to work on, so I implemented this by adding a new public variable to store color data on the server object. This required changing from a <textarea> to a <div> for representing the readonly console area, so changes were made to accompany this. Users will now be able to color messages accordingly by calling the updated Log(string,string) API.

Below is the detailed commit changes, let me know what you think of this implementation!

Update to support custom coloring of console messages. This was achieved
by adding a struct[] to the Server.cs object containing a string name
and Color32 value for each user defined message. Users can add whatever
colors they wish to this array, and when logging messages can specify
which color to use when logging using Log(string, string).

Changes to each object:
Console.cs:
- Added Log(string,string) to allow for logging of messages with
  specific color
- Add Output(bool) to determine if the output should use html for
  coloring
- Add RegisterMessageColors to allow for the Server to propogate the
  user chosen colors to the Console instance

Server.cs
- Add MessageColors struct containing string and Color
-  Add messageColors public  MessageColors[]
- Pass messageColors to the Console instance

console.css
- Style updates to account for use of div over textarea for displaying
  readonly console area

index.html
- Use a div instead of a textarea for the readonly console area
