### PR TITLE
Production fixes

### DIFF
--- a/CUDLR/Scripts/Server.cs
+++ b/CUDLR/Scripts/Server.cs
@@ -41,6 +41,9 @@ namespace CUDLR {
     [SerializeField]
     public int Port = 55055;
 
+    [SerializeField]
+    public bool RegisterLogCallback = false;
+
     private static Thread mainThread;
     private static string fileRoot;
     private static HttpListener listener = new HttpListener();
@@ -182,12 +185,16 @@ namespace CUDLR {
     }
 
     void OnEnable() {
+      if (RegisterLogCallback) {
       // Capture Console Logs
       Application.RegisterLogCallback(Console.LogCallback);
     }
+    }
 
     void OnDisable() {
+      if (RegisterLogCallback) {
       Application.RegisterLogCallback(null);
+    }
     }
 
     void Update() {

--- a/CUDLR/Scripts/Server.cs
+++ b/CUDLR/Scripts/Server.cs
@@ -66,9 +66,6 @@ namespace CUDLR {
       mainThread = Thread.CurrentThread;
       fileRoot = Path.Combine(Application.streamingAssetsPath, "CUDLR");
 
-      RegisterRoutes();
-      RegisterFileHandlers();
-
       // Start server
       Debug.Log("Starting CUDLR Server on port : " + Port);
       listener.Prefixes.Add("http://*:"+Port+"/");
@@ -78,10 +75,11 @@ namespace CUDLR {
       StartCoroutine(HandleRequests());
     }
 
+
+
     private void RegisterRoutes() {
-
-      registeredRoutes = new List<RouteAttribute>();
-
+      if ( registeredRoutes == null ) {
+        registeredRoutes = new List<RouteAttribute>();
 
       foreach(Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()) {
         foreach(Type type in assembly.GetTypes()) {
@@ -109,6 +107,8 @@ namespace CUDLR {
             }
           }
         }
+      }
+        RegisterFileHandlers();
       }
     }
 
@@ -203,6 +203,8 @@ namespace CUDLR {
     }
 
     void HandleRequest(RequestContext context) {
+      RegisterRoutes();
+
       try {
         bool handled = false;
 


### PR DESCRIPTION
Three fixes from WZ: 
 - Don't always call RegisterLogCallback
 - Cleanup the socket listener on pause / shutdown
 - Defer inspection of the Assembly until the first client request