### PR TITLE
Fixing a deprecation warning for the log-callback registration

### DIFF
--- a/CUDLR/Scripts/Server.cs
+++ b/CUDLR/Scripts/Server.cs
@@ -201,13 +201,21 @@ namespace CUDLR {
     void OnEnable() {
       if (RegisterLogCallback) {
         // Capture Console Logs
+#if UNITY_5_3_OR_NEWER
+        Application.logMessageReceived += Console.LogCallback;
+#else
         Application.RegisterLogCallback(Console.LogCallback);
+#endif
       }
     }
 
     void OnDisable() {
       if (RegisterLogCallback) {
+#if UNITY_5_3_OR_NEWER
+        Application.logMessageReceived -= Console.LogCallback;
+#else
         Application.RegisterLogCallback(null);
+#endif
       }
     }
 


### PR DESCRIPTION
In Unity 5 the registration mechanic for logging-callbacks was changed such that multiple callbacks could be registered at once. Thankfully fixing the deprecation-warning by using the new API is a relatively small compilation-branch.