### PR TITLE
adds colorization support for warnings, errors, exceptions, and the help output

### DIFF
--- a/CUDLR/Scripts/Console.cs
+++ b/CUDLR/Scripts/Console.cs
@@ -86,7 +86,7 @@ namespace CUDLR {
         help += string.Format("\n{0} : {1}", cmd.m_command, cmd.m_help);
       }
 
-      Log(help);
+      Log("<span class='Help'>" + help + "</span>");
     }
 
     /* Find command based on partial string */
@@ -108,9 +108,11 @@ namespace CUDLR {
 
     /* Callback for Unity logging */
     public static void LogCallback (string logString, string stackTrace, LogType type) {
-      Console.Log(logString);
       if (type != LogType.Log) {
-        Console.Log(stackTrace);
+        Console.Log("<span class='" + type + "'>" + logString);
+        Console.Log(stackTrace + "</span>");
+      } else {
+        Console.Log(logString);
       }
     }
 

--- a/StreamingAssets/CUDLR/console.css
+++ b/StreamingAssets/CUDLR/console.css
@@ -1,16 +1,54 @@
-textarea {resize:none;}
+html, body {
+	height:99%;
+}
+
+textarea {
+	resize:none;
+}
 
 body.console {
   background-color:black;
 }
+
+div.console {
+  height:100%;
+  width:100%;
+  background-color:#383838;
+  color:#F0F0F0;
+  font-size:14px;
+  font-family:monospace;
+  overflow-y:auto;
+  overflow-x:auto;
+  white-space:normal;
+  word-wrap:break-word;
+}
+
 textarea.console {
   width:100%;
   background-color:#383838;
   color:#F0F0F0;
   font-size:14px;
-  font-family:;"Courier New", Courier, monospace;
-
+  font-family:monospace;
+  position:fixed;
+  bottom:0%;
 }
-#output {
-  height:500px;
+
+span.Warning {
+	color:#f4e542;
+}
+
+span.Assert {
+	color:#f4e542;
+}
+
+span.Error {
+	color:#ff0000;
+}
+
+span.Exception {
+	color:#ff0000;
+}
+
+span.Help {
+	color:#16f3ff;
 }

--- a/StreamingAssets/CUDLR/index.html
+++ b/StreamingAssets/CUDLR/index.html
@@ -19,7 +19,7 @@
 
       function runCommand(command) {
         scrollBottom();
-        $.get("console/run?command="+encodeURI(encodeURIComponent(command)), function (data, status) {
+        $.get("console/run?command="+command, function (data, status) {
           updateConsole(function () {
             updateCommand(commandIndex - 1);
           });
@@ -32,7 +32,8 @@
           // Check if we are scrolled to the bottom to force scrolling on update
           var output = $('#output');
           shouldScroll = (output[0].scrollHeight - output.scrollTop()) == output.innerHeight();
-          output.val(String(data));
+          output.html(String(data).replace(/\n|\r/g, '<br>') + "<br><br><br>");
+          //console.log(String(data));
           if (callback) callback();
           if (shouldScroll) scrollBottom();
         });
@@ -80,7 +81,7 @@
   </head>
 
   <body class="console">
-    <textarea id="output" class="console" readOnly></textarea>
+    <div id="output" class="console">asdfasdf</div>
     <textarea id="input" class="console" autofocus rows="1"></textarea>
 
     <script>

--- a/StreamingAssets/CUDLR/index.html
+++ b/StreamingAssets/CUDLR/index.html
@@ -19,7 +19,7 @@
 
       function runCommand(command) {
         scrollBottom();
-        $.get("console/run?command="+command, function (data, status) {
+        $.get("console/run?command="+encodeURI(encodeURIComponent(command)), function (data, status) {
           updateConsole(function () {
             updateCommand(commandIndex - 1);
           });


### PR DESCRIPTION
This doesn't let you do custom colors for arbitrary logs (so no custom logging command is required), it only adds colors to Unity warnings, exceptions, errors, and the CUDLR help output.

Pretty minimal changes required to do this. The biggest change was converting the textarea to a div.

A positive sideffect of this was also being able to make it 100% height instead of just 500 pixels.

Important note: I didn't test this code in this fork, only in our existing codebase which has other CUDLR changes and is based on an older version. But since the changes are minimal I don't think there should be any problems.