### PR TITLE
restored ability to copy text and improved should scroll logic

### DIFF
--- a/StreamingAssets/CUDLR/console.css
+++ b/StreamingAssets/CUDLR/console.css
@@ -52,3 +52,14 @@ span.Exception {
 span.Help {
 	color:#16f3ff;
 }
+
+button#pauseUpdates {
+  width:150px;
+  height:40px;
+  position:fixed;
+  float:right;
+  margin-right:50px;
+  margin-top:10px;
+  right:0px;
+  opacity:.5;
+}

--- a/StreamingAssets/CUDLR/index.html
+++ b/StreamingAssets/CUDLR/index.html
@@ -12,6 +12,7 @@
     <script>
       var commandIndex = -1;
       var hash = null;
+      var isUpdatePaused = false;
 
       function scrollBottom() {
         $('#output').scrollTop($('#output')[0].scrollHeight);
@@ -28,11 +29,13 @@
       }
 
       function updateConsole(callback) {
+        if (isUpdatePaused) return;
         $.get("console/out", function (data, status) {
           // Check if we are scrolled to the bottom to force scrolling on update
           var output = $('#output');
-          shouldScroll = (output[0].scrollHeight - output.scrollTop()) == output.innerHeight();
+          shouldScroll = Math.abs((output[0].scrollHeight - output.scrollTop()) - output.innerHeight()) < 5;
           output.html(String(data).replace(/\n|\r/g, '<br>') + "<br><br><br>");
+          //console.log(shouldScroll + " := " + output[0].scrollHeight + " - " + output.scrollTop() + " (" + Math.abs((output[0].scrollHeight - output.scrollTop()) - output.innerHeight()) + ") == " + output.innerHeight());
           //console.log(String(data));
           if (callback) callback();
           if (shouldScroll) scrollBottom();
@@ -81,10 +84,18 @@
   </head>
 
   <body class="console">
-    <div id="output" class="console">asdfasdf</div>
+    <button id="pauseUpdates">Pause Updates</button>
+    <div id="output" class="console"></div>
     <textarea id="input" class="console" autofocus rows="1"></textarea>
 
     <script>
+      // setup our pause updates button
+      $("#pauseUpdates").click(function() {
+        //console.log("pause updates " + isUpdatePaused);
+        isUpdatePaused = !isUpdatePaused;
+        $("#pauseUpdates").html(isUpdatePaused ? "Resume Updates" : "Pause Updates");
+      });
+
       $("#input").keydown( function (e) {
         if (e.keyCode == 13) { // Enter
           // we don't want a line break in the console


### PR DESCRIPTION
* added a "pause updates" button to the top right of the log screen so you can pause the updating and copy text from the log (side effect of changing the log from a textarea to a div (to support colors) was that it broke your ability to copy text if the log is updating).
* updated the "should scroll" logic so its more reliable.